### PR TITLE
Filter out own user retweets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ lambda
 /.env
 
 tsconfig.tsbuildinfo
+/coverage

--- a/src/__tests__/unit/handlers/tweet.test.ts
+++ b/src/__tests__/unit/handlers/tweet.test.ts
@@ -1,50 +1,88 @@
 import { filterTweets } from '../../../handler';
 
 describe('filterTweets function', () => {
+	const ticker = 'TESTSEITOKEN';
+	const username = 'testuser';
 	it('should filter tweets that contain the ticker with $ or #', () => {
+
 		const tweets = [
 			{
-				text: 'Post containing token name $TESTSEITOKEN',
+				text: `Post containing token name $${ticker}`
 			},
 			{
-				text: 'Post containing token name #TESTSEITOKEN',
+				text: `Post containing token name #${ticker}`
 			},
 			{
-				text: 'Post containing token name TESTSEITOKEN',
-			},
+				text: `Post containing token name ${ticker}`
+			}
 		];
-		const ticker = 'TESTSEITOKEN';
-		const result = filterTweets(tweets, ticker);
+		const result = filterTweets(tweets, ticker, username);
 		expect(result).toEqual([
 			{
-				text: 'Post containing token name $TESTSEITOKEN',
+				text: `Post containing token name $${ticker}`
 			},
 			{
-				text: 'Post containing token name #TESTSEITOKEN',
-			},
+				text: `Post containing token name #${ticker}`
+			}
 		]);
 	});
 	it('should not filter out tweets with mixed case $ or #', () => {
 		const tweets = [
 			{
-				text: 'Post containing token name $tESTSEITOKEN',
+				text: 'Post containing token name $tESTSEITOKEN'
 			},
 			{
-				text: 'Post containing token name #Testseitoken',
+				text: 'Post containing token name #Testseitoken'
 			},
 			{
-				text: 'Post containing token name TESTSEITOKEN',
-			},
+				text: 'Post containing token name TESTSEITOKEN'
+			}
 		];
 		const ticker = 'TESTSEITOKEN';
-		const result = filterTweets(tweets, ticker);
+		const result = filterTweets(tweets, ticker, username);
 		expect(result).toEqual([
 			{
 				text: 'Post containing token name $tESTSEITOKEN'
 			},
 			{
-				text: 'Post containing token name #Testseitoken',
-			},
+				text: 'Post containing token name #Testseitoken'
+			}
 		]);
+	});
+	it('should filter out retweets of own user tweets', () => {
+		const tweets = [
+			{
+				text: `RT @${username}: Post containing token name $${ticker}`
+			},
+			{
+				text: `RT @${username}: Post containing token name #${ticker}`
+			},
+			{
+				text: `RT @${username}: Post containing token name ${ticker}`
+			}
+		];
+		const result = filterTweets(tweets, ticker, username);
+		expect(result).toEqual([]);
+	});
+
+	it('should filter out retweets of own user tweets, but let others through', () => {
+		const tweets = [
+			{
+				text: `RT @${username}: Post containing token name $${ticker}`
+			},
+			{
+				text: `RT @${username}: Post containing token name #${ticker}`
+			},
+			{
+				text: `RT @${username}: Post containing token name ${ticker}`
+			},
+			{
+				text: 'Post containing token name $tESTSEITOKEN'
+			}
+		];
+		const result = filterTweets(tweets, ticker, username);
+		expect(result).toEqual([{
+			text: 'Post containing token name $tESTSEITOKEN'
+		}]);
 	});
 });


### PR DESCRIPTION
**Context**
If user retweets own tweet, points should not be counted. These tweets contain `RT @<twitter username>:` and can filtered out.

**Fix**
Add logic to filter out own retweets. That is tweet containing  `RT @<twitter username>:` text.

**Testing**
Unit testing